### PR TITLE
Refactor IResult methods for simplicity and performance

### DIFF
--- a/TransactionHelpers/Interface/IResult.cs
+++ b/TransactionHelpers/Interface/IResult.cs
@@ -69,7 +69,7 @@ public interface IResult
     /// <param name="appendResultValues">Append values if the results have the same value type.</param>
     /// <returns>True if the appended result has no error, otherwise false.</returns>
     [MemberNotNullWhen(false, nameof(Error))]
-    bool Success<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TAppend>(TAppend resultAppend, bool appendResultValues)
+    bool Success<TAppend>(TAppend resultAppend, bool appendResultValues)
         where TAppend : IResult;
 
     /// <summary>
@@ -79,7 +79,7 @@ public interface IResult
     /// <param name="resultAppend">The result to append.</param>
     /// <returns>True if the appended result has no error, otherwise false.</returns>
     [MemberNotNullWhen(false, nameof(Error))]
-    bool Success<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TAppend>(TAppend resultAppend)
+    bool Success<TAppend>(TAppend resultAppend)
         where TAppend : IResult;
 
     /// <summary>
@@ -92,7 +92,7 @@ public interface IResult
     /// <param name="value">The out result value.</param>
     /// <returns>False if the appended result has an error or no value, otherwise true.</returns>
     [MemberNotNullWhen(false, nameof(Error))]
-    bool Success<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TAppend, TAppendValue>(TAppend resultAppend, bool appendResultValues, out TAppendValue? value)
+    bool Success<TAppend, TAppendValue>(TAppend resultAppend, bool appendResultValues, out TAppendValue? value)
         where TAppend : IResult<TAppendValue>;
 
     /// <summary>
@@ -104,7 +104,7 @@ public interface IResult
     /// <param name="value">The out result value.</param>
     /// <returns>False if the appended result has an error or no value, otherwise true.</returns>
     [MemberNotNullWhen(false, nameof(Error))]
-    bool Success<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TAppend, TAppendValue>(TAppend resultAppend, out TAppendValue? value)
+    bool Success<TAppend, TAppendValue>(TAppend resultAppend, out TAppendValue? value)
         where TAppend : IResult<TAppendValue>;
 
     /// <summary>
@@ -115,7 +115,7 @@ public interface IResult
     /// <param name="appendResultValues">Append values if the results have the same value type.</param>
     /// <returns>True if the appended result has no error and has a value, otherwise false.</returns>
     [MemberNotNullWhen(false, nameof(Error))]
-    bool SuccessAndHasValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TAppend>(TAppend resultAppend, bool appendResultValues)
+    bool SuccessAndHasValue<TAppend>(TAppend resultAppend, bool appendResultValues)
         where TAppend : IResult;
 
     /// <summary>
@@ -125,7 +125,7 @@ public interface IResult
     /// <param name="resultAppend">The result to append.</param>
     /// <returns>True if the appended result has no error and has a value, otherwise false.</returns>
     [MemberNotNullWhen(false, nameof(Error))]
-    bool SuccessAndHasValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TAppend>(TAppend resultAppend)
+    bool SuccessAndHasValue<TAppend>(TAppend resultAppend)
         where TAppend : IResult;
 
     /// <summary>
@@ -138,7 +138,7 @@ public interface IResult
     /// <param name="value">The out result value.</param>
     /// <returns>False if the appended result has an error or no value, otherwise true.</returns>
     [MemberNotNullWhen(false, nameof(Error))]
-    bool SuccessAndHasValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TAppend, TAppendValue>(TAppend resultAppend, bool appendResultValues, [NotNullWhen(true)] out TAppendValue? value)
+    bool SuccessAndHasValue<TAppend, TAppendValue>(TAppend resultAppend, bool appendResultValues, [NotNullWhen(true)] out TAppendValue? value)
         where TAppend : IResult<TAppendValue>;
 
     /// <summary>
@@ -150,7 +150,7 @@ public interface IResult
     /// <param name="value">The out result value.</param>
     /// <returns>False if the appended result has an error or no value, otherwise true.</returns>
     [MemberNotNullWhen(false, nameof(Error))]
-    bool SuccessAndHasValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TAppend, TAppendValue>(TAppend resultAppend, [NotNullWhen(true)] out TAppendValue? value)
+    bool SuccessAndHasValue<TAppend, TAppendValue>(TAppend resultAppend, [NotNullWhen(true)] out TAppendValue? value)
         where TAppend : IResult<TAppendValue>;
 }
 

--- a/TransactionHelpers/Result.cs
+++ b/TransactionHelpers/Result.cs
@@ -68,7 +68,7 @@ public class Result : IResult
 
     /// <inheritdoc/>
     [MemberNotNullWhen(false, nameof(Error))]
-    public bool Success<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TAppend>(TAppend resultAppend, bool appendResultValues)
+    public bool Success<TAppend>(TAppend resultAppend, bool appendResultValues)
         where TAppend : IResult
     {
         this.WithResult(appendResultValues, resultAppend);
@@ -77,7 +77,7 @@ public class Result : IResult
 
     /// <inheritdoc/>
     [MemberNotNullWhen(false, nameof(Error))]
-    public virtual bool Success<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TAppend>(TAppend resultAppend)
+    public virtual bool Success<TAppend>(TAppend resultAppend)
         where TAppend : IResult
     {
         this.WithResult(resultAppend);
@@ -86,7 +86,7 @@ public class Result : IResult
 
     /// <inheritdoc/>
     [MemberNotNullWhen(false, nameof(Error))]
-    public bool Success<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TAppend, TAppendValue>(TAppend resultAppend, bool appendResultValues, out TAppendValue? value)
+    public bool Success<TAppend, TAppendValue>(TAppend resultAppend, bool appendResultValues, out TAppendValue? value)
         where TAppend : IResult<TAppendValue>
     {
         this.WithResult(appendResultValues, resultAppend);
@@ -96,7 +96,7 @@ public class Result : IResult
 
     /// <inheritdoc/>
     [MemberNotNullWhen(false, nameof(Error))]
-    public virtual bool Success<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TAppend, TAppendValue>(TAppend resultAppend, out TAppendValue? value)
+    public virtual bool Success<TAppend, TAppendValue>(TAppend resultAppend, out TAppendValue? value)
         where TAppend : IResult<TAppendValue>
     {
         this.WithResult(resultAppend);
@@ -106,14 +106,14 @@ public class Result : IResult
 
     /// <inheritdoc/>
     [MemberNotNullWhen(false, nameof(Error))]
-    public bool SuccessAndHasValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TAppend>(TAppend resultAppend, bool appendResultValues)
+    public bool SuccessAndHasValue<TAppend>(TAppend resultAppend, bool appendResultValues)
         where TAppend : IResult
     {
         this.WithResult(appendResultValues, resultAppend);
-        if (typeof(TAppend).GetProperty(nameof(IResult<object>.HasNoValue), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance) is PropertyInfo hasNoValuePropertyInfo &&
-            hasNoValuePropertyInfo.GetValue(resultAppend) is bool hasNoValue)
+
+        if (resultAppend.InternalValueType != null)
         {
-            return !resultAppend.IsError && !hasNoValue;
+            return !resultAppend.IsError && resultAppend.InternalValue != null;
         }
 
         return !resultAppend.IsError;
@@ -121,14 +121,14 @@ public class Result : IResult
 
     /// <inheritdoc/>
     [MemberNotNullWhen(false, nameof(Error))]
-    public virtual bool SuccessAndHasValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TAppend>(TAppend resultAppend)
+    public virtual bool SuccessAndHasValue<TAppend>(TAppend resultAppend)
         where TAppend : IResult
     {
         this.WithResult(resultAppend);
-        if (typeof(TAppend).GetProperty(nameof(IResult<object>.HasNoValue), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance) is PropertyInfo hasNoValuePropertyInfo &&
-            hasNoValuePropertyInfo.GetValue(resultAppend) is bool hasNoValue)
+
+        if (resultAppend.InternalValueType != null)
         {
-            return !resultAppend.IsError && !hasNoValue;
+            return !resultAppend.IsError && resultAppend.InternalValue != null;
         }
 
         return !resultAppend.IsError;
@@ -136,7 +136,7 @@ public class Result : IResult
 
     /// <inheritdoc/>
     [MemberNotNullWhen(false, nameof(Error))]
-    public bool SuccessAndHasValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TAppend, TAppendValue>(TAppend resultAppend, bool appendResultValues, [NotNullWhen(true)] out TAppendValue? value)
+    public bool SuccessAndHasValue<TAppend, TAppendValue>(TAppend resultAppend, bool appendResultValues, [NotNullWhen(true)] out TAppendValue? value)
         where TAppend : IResult<TAppendValue>
     {
         this.WithResult(appendResultValues, resultAppend);
@@ -146,7 +146,7 @@ public class Result : IResult
 
     /// <inheritdoc/>
     [MemberNotNullWhen(false, nameof(Error))]
-    public virtual bool SuccessAndHasValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TAppend, TAppendValue>(TAppend resultAppend, [NotNullWhen(true)] out TAppendValue? value)
+    public virtual bool SuccessAndHasValue<TAppend, TAppendValue>(TAppend resultAppend, [NotNullWhen(true)] out TAppendValue? value)
         where TAppend : IResult<TAppendValue>
     {
         this.WithResult(resultAppend);


### PR DESCRIPTION
Refactor IResult methods for simplicity and performance

Removed [DynamicallyAccessedMembers] attribute from the
generic type parameters of the Success and SuccessAndHasValue
methods in the IResult interface and Result class. Updated
the implementation to check for InternalValue instead of
using reflection to access the HasNoValue property, enhancing
both performance and readability.