### PR TITLE
chore: change dependabot schedule to hourly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,8 @@ updates:
     directory: "/"
     open-pull-requests-limit: 100
     schedule:
-      interval: "daily"
+      interval: "cron"
+      cronjob: "0 * * * *"
 
     allow:
       - dependency-type: "direct"


### PR DESCRIPTION
Changes dependabot schedule from `daily` to hourly using `interval: "cron"` with `cronjob: "0 * * * *"`.